### PR TITLE
Update Ford E-Series generations: Add Wikipedia reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Ford E-Series
 
+This repository contains signal set configurations for the Ford E-Series, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Ford E-Series.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Ford_E-Series"
+
 generations:
   - name: "First Generation (Econoline)"
     start_year: 1961


### PR DESCRIPTION
- Added references array with Ford E-Series Wikipedia article link
- Updated README.md with standard template
- Verified generation data matches Wikipedia sources

Wikipedia infobox confirms:
- Production: 1960–present
- Model years: 1961–present
- Full-size van classification

Generation structure validated:
- First Generation (Econoline): 1961-1967
- Second Generation: 1968-1974
- Third Generation: 1975-1991
- Fourth Generation: 1992-2014 (passenger/cargo), continues as cutaway 2015-present
- Cutaway/Stripped Chassis continuation: 2015-present

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
